### PR TITLE
call to file_markup() for protected files now sets 'preload' to 'none' in $props

### DIFF
--- a/items/show.php
+++ b/items/show.php
@@ -77,7 +77,7 @@ echo head(array('title' => $title, 'bodyclass' => 'items show' .  (($hasImages) 
                                " - " .
                                $nonImage->mime_type; ?>
                 </div>
-                <?php echo file_markup($nonImage, array(), NULL); ?>
+                <?php echo file_markup($nonImage, array("preload"=>"none"), NULL); ?>
             <?php /* Use older Omeka Theming Functions for everything else */ ?>
             <?php else: ?>
                 <div class="element-text"><a href="<?php echo file_display_url($nonImage, 'original'); ?>"><?php echo metadata($nonImage, 'display_title'); ?> - <?php echo $nonImage->mime_type; ?></a></div>


### PR DESCRIPTION
This is to fix problem with Firefox hanging the PHP engine when attempting to preload the 7th protected file. Uses new feature in StreamOnly plugin: use $props to set `preload="none"` when calling file_markup() in items/show.php.